### PR TITLE
Improve scripts task

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ module.exports = function(options) {
       on: path.join(base_dir, sources.scripts.src || 'scripts', '**/*.{coffee,litcoffee}'),
       cwd: path.join(base_dir, sources.scripts.src || 'scripts'),
       dest: sources.scripts.dest || 'js',
-      glob: '**/' + (options.bundle ? 'index' : '*') + '.{coffee,litcoffee}',
+      glob: '**/*.{coffee,litcoffee}',
       filter: sources.scripts.filter || []
     },
     views: {

--- a/lib/tasks/scripts.js
+++ b/lib/tasks/scripts.js
@@ -37,7 +37,7 @@ module.exports = function(options) {
     };
 
     glob
-      .sync(path.join(options.paths.scripts.cwd, options.paths.scripts.glob))
+      .sync(src)
       .forEach(function(file) {
         var test_file = path.relative(options.paths.scripts.cwd, file);
 
@@ -45,6 +45,12 @@ module.exports = function(options) {
           var fixed_file = path.relative(options.paths.scripts.cwd, file),
               fixed_entry = options.bundle && options.bundle.compact ? '' : '$1$2',
               fixed_keyname = fixed_file.replace(/(?:(\/?)(\w+))?.(?:lit)?coffee$/, fixed_entry);
+
+          //if the file is index or have the same name that parent folder
+          var patt = /\b(\w+)\/+((\1|index)\.(coffee|litcoffee))/;
+          if(patt.test(fixed_file) == false){
+            return
+          }
 
           var dest_file = path.join(dest, fixed_keyname + '.js');
 


### PR DESCRIPTION
This will enable to have scripts with the same name that
parent folder like this:

``` bash
/scripts/sites/some/index.coffee
/scripts/sites/some/some.coffee
```
