### PR TITLE
remove prefixed icons

### DIFF
--- a/lib/stubs/icons/template.less
+++ b/lib/stubs/icons/template.less
@@ -1,8 +1,8 @@
 // {{comment}}
 
 //Default values
-@iconWidth: 1.23em;
-@iconHeight: 0.9em;
+/*@iconWidth: 1.23em;*/
+/*@iconHeight: 0.9em;*/
 
 
 @font-face {
@@ -17,16 +17,16 @@
 		url("{{fontPath}}/{{fontName}}.svg#{{fontName}}") format('svg');
 	font-weight: normal;
 	font-style: normal;
+
+  // semantic-ui icon rules
+  /*font-variant: normal;*/
+  /*text-decoration: inherit;*/
+  /*text-transform: none;*/
 }
 
 .{{className}} {
 	display: inline-block;
 	vertical-align: middle;
-
-	// width: @iconWidth;
-	// height: @iconHeight;
-	// margin: 0em 0.25rem 0em 0em;
-
 	line-height: 1;
 	margin: -0.1em 0;
 
@@ -43,7 +43,21 @@
 	text-transform: none;
 
 	backface-visibility: hidden;
+
+  // semantic-ui icon rules
+	/*width: 1.18em;*/
+	/*height: 1em;*/
+	/*margin: 0em 0.25rem 0em 0em;*/
+  /*opacity: 1;*/
+  /*text-decoration: inherit;*/
+  /*text-align: center;*/
+  /*-webkit-backface-visibility: hidden;*/
 }
+
+// semantic-ui icon rules
+/*.{{className}}:before {*/
+  /*backface: none !important;*/
+/*}*/
 
 .{{className}}(@content: '') {
 	&:before {

--- a/lib/tasks/icons.js
+++ b/lib/tasks/icons.js
@@ -1,4 +1,4 @@
-'us strict';
+'use strict';
 
 var path = require('path'),
     iconfont = require('gulp-iconfont'),

--- a/lib/tasks/icons.js
+++ b/lib/tasks/icons.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var path = require('path'),
+    through = require('through2'),
     iconfont = require('gulp-iconfont'),
     svgmin = require('gulp-svgmin'),
     swig = require('gulp-swig'),
@@ -13,6 +14,7 @@ module.exports = function(options) {
 
   var compile = function(stream, errorHandler) {
     return stream
+      .pipe(rewriteGlobals())
       .pipe(svgmin())
       .pipe(iconfont(options.paths.icons.iconFont))
       .on('error', errorHandler)
@@ -21,7 +23,7 @@ module.exports = function(options) {
 
   var global_path = path.join(process.cwd(), 'src', options.cwd, 'sites', '_global', 'icons', options.paths.icons.glob)
   var local_path  = path.join(options.paths.icons.cwd, options.paths.icons.glob);
-  var src_paths   = [global_path, local_path];
+  var src_paths   = [local_path, global_path];
 
   return {
     src: src_paths,
@@ -29,6 +31,18 @@ module.exports = function(options) {
     pipe: compile
   }
 
+}
+
+var rewriteGlobals = function() {
+  var icons = []
+  return through.obj(function(file, e, cb) { 
+      var fname = file.relative
+      if (icons.indexOf(fname) === -1) {
+        icons.push(fname)
+        this.push(file)
+      }
+      cb()
+    })
 }
 
 var handleIconGlyphs = function(options, gulp) {

--- a/lib/tasks/icons.js
+++ b/lib/tasks/icons.js
@@ -1,4 +1,4 @@
-'use strict';
+'us strict';
 
 var path = require('path'),
     iconfont = require('gulp-iconfont'),
@@ -19,8 +19,12 @@ module.exports = function(options) {
       .on('glyphs', handleIconGlyphs(options.paths.icons, options.gulp))
   }
 
+  var global_path = path.join(process.cwd(), 'src', options.cwd, 'sites', '_global', 'icons', options.paths.icons.glob)
+  var local_path  = path.join(options.paths.icons.cwd, options.paths.icons.glob);
+  var src_paths   = [global_path, local_path];
+
   return {
-    src: path.join(options.paths.icons.cwd, options.paths.icons.glob),
+    src: src_paths,
     dest: path.join(options.paths.dest, options.paths.fonts.dest),
     pipe: compile
   }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "rainbow": "./bin/cli.js"
   },
   "dependencies": {
-    "bower" : "1.7.0",
     "ansi-rainbow": "0.0.8",
+    "bower": "1.7.0",
     "browser-sync": "^2.9.9",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.10.0",
@@ -43,6 +43,7 @@
     "multimatch": "^2.0.0",
     "node-libs-browser": "^0.5.3",
     "rimraf": "^2.4.3",
+    "through2": "^2.0.0",
     "webpack-stream": "^2.1.1",
     "yargs": "^3.26.0"
   },


### PR DESCRIPTION
Concat global icons with local ones to generate svg icon font without site-prefix class.
If there's a global/local duplicated icon it favor the local one making possible to use site specific icon instead the generic global
